### PR TITLE
CTT-57 Fix exception when updating incidents

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -89,7 +89,7 @@ class ServiceProvider extends BaseServiceProvider
         /**
          * Send Slack notification on incident updates.
          */
-        $events->listen('CachetHQ\Cachet\Bus\Events\Incident\IncidentWasUpdatedEvent', function (IncidentWasUpdatedEvent $event) {
+        $events->listen('CachetHQ\Cachet\Bus\Events\Incident\IncidentWasUpdatedEvent-muted', function (IncidentWasUpdatedEvent $event) {
             $handler = new IncidentWasUpdatedHandler(
                 $event->incident->id,
                 $event->incident->status,


### PR DESCRIPTION
The issue is really in the fact that route('status-page') is not defined correctly for the title-link in the new incidents and update incident events of cachet.
More info of the issue is described [here](https://github.com/mrbase/cachet-slack-integration/issues/7)

However, after confirming with the Infrastructure team, we really don't need to receive updates about incidents from status.toptal.net, since we already have Slack notifications from our Incident management framework.
Since that's the case, I will just mute the update incident event.